### PR TITLE
feat(terraform): add repo merge defaults and remote state CI/docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# Terraform remote state (tfstate.dev) and GitHub provider
+TF_HTTP_USERNAME=owner/repo                         # e.g. surefirev2/terraform-github
+TF_HTTP_PASSWORD=your_github_pat_here               # GitHub PAT with repo access; regenerate if you see "invalid auth"
+TF_VAR_github_token=your_github_pat_here            # Same token for GitHub provider
+
 # API Keys (Required to enable respective provider)
 ANTHROPIC_API_KEY=your_anthropic_api_key_here       # Required: Format: sk-ant-api03-...
 PERPLEXITY_API_KEY=your_perplexity_api_key_here     # Optional: Format: pplx-...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 # Makefile
+#
+# Remote state (tfstate.dev) requires .env with:
+#   TF_HTTP_USERNAME=surefirev2/terraform-github   # owner/repo for HTTP Basic auth
+#   TF_HTTP_PASSWORD=<GitHub PAT or token>         # must have repo access; if you see
+#   TF_VAR_github_token=<same token>               # "invalid auth", regenerate PAT with repo scope
+# Fine-grained PATs: grant Metadata (or Contents) read for tfstate.dev; for plan, also
+#   grant Security events / Dependabot alerts read so the GitHub provider can read repo state.
 
 # Docker image
 TERRAFORM_IMAGE = terraform

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,22 +2,22 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.5.3"
+  version     = "2.7.0"
   constraints = "~> 2.5"
   hashes = [
-    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
-    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
-    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
-    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
+    "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
+    "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
+    "zh:643256547b155459c45e0a3e8aab0570db59923c68daf2086be63c444c8c445b",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
-    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
-    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
-    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
-    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
-    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
-    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
-    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+    "zh:7aa4d0b853f84205e8cf79f30c9b2c562afbfa63592f7231b6637e5d7a6b5b27",
+    "zh:7dc251bbc487d58a6ab7f5b07ec9edc630edb45d89b761dba28e0e2ba6b1c11f",
+    "zh:7ee0ca546cd065030039168d780a15cbbf1765a4c70cd56d394734ab112c93da",
+    "zh:b1d5d80abb1906e6c6b3685a52a0192b4ca6525fe090881c64ec6f67794b1300",
+    "zh:d81ea9856d61db3148a4fc6c375bf387a721d78fc1fea7a8823a027272a47a78",
+    "zh:df0a1f0afc947b8bfc88617c1ad07a689ce3bd1a29fd97318392e6bdd32b230b",
+    "zh:dfbcad800240e0c68c43e0866f2a751cff09777375ec701918881acf67a268da",
   ]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,6 +61,11 @@ resource "github_repository" "repos" {
   has_projects = var.repository_settings.has_projects
   has_wiki     = var.repository_settings.has_wiki
 
+  allow_auto_merge       = true
+  allow_merge_commit     = false
+  allow_update_branch    = true
+  delete_branch_on_merge = true
+
   lifecycle {
     ignore_changes = [
       vulnerability_alerts,


### PR DESCRIPTION
## Description
Add Terraform repo merge defaults and remote state CI/docs. Rebased on main; workflow uses existing `terraform-setup` composite action (no .env step changes in this PR).

## Type of Change
- [x] Feature (repo merge defaults)
- [x] Docs (Makefile, .env.example)

## Changes Made
- **terraform/main.tf**: Set repo defaults `allow_auto_merge=true`, `allow_merge_commit=false`, `allow_update_branch=true`, `delete_branch_on_merge=true` for all managed repos.
- **Makefile**: Document remote state .env vars (TF_HTTP_USERNAME, TF_HTTP_PASSWORD, TF_VAR_github_token); remove `-refresh=false` default so plan uses full refresh with classic token.
- **.env.example**: Add Terraform section for TF_HTTP_USERNAME, TF_HTTP_PASSWORD, TF_VAR_github_token.
- **terraform/.terraform.lock.hcl**: Provider lock file updates.

## Testing
- `make validate` and `make plan` run successfully locally with classic token (repo + read:org).
- GHA will run plan on PR and apply on push to main (uses `.github/actions/terraform-setup` for token/.env).

## Checklist
- [x] Pre-commit passed
- [x] Terse semantic commit
- [x] Rebased on origin/main