### PR TITLE
fix(ci): apply with -refresh=false to avoid 403

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,7 @@ validate: init
         -w /workspace \
         $(TERRAFORM_IMAGE) validate
 
-# Plan without refresh to avoid 403 when reading vulnerability_alerts (token/org lacks access).
-# Apply still refreshes; use a token with security access or ignore_vulnerability_alerts_during_read.
+# Plan and apply without refresh to avoid 403 when reading vulnerability_alerts (token/org lacks access).
 .PHONY: plan
 plan: init
 	mkdir -p $(PLAN_DIR)
@@ -77,7 +76,7 @@ apply: init
         -u $(USER_ID):$(GROUP_ID) \
         -v $(PWD)/$(TERRAFORM_DIR):/workspace \
         -w /workspace \
-        $(TERRAFORM_IMAGE) apply -auto-approve
+        $(TERRAFORM_IMAGE) apply -refresh=false -auto-approve
 
 .PHONY: destroy
 destroy: init


### PR DESCRIPTION
**Summary**
Adds `-refresh=false` to `make apply` so CI apply on merge to main does not refresh state and hit the 403 when reading repository vulnerability_alerts (token/org lacks access).

**Type of change**
- Fix (CI)

**Changes made**
- Makefile: `apply` target now runs `terraform apply -refresh=false -auto-approve`.
- Comment updated to state both plan and apply skip refresh for the same reason.

**Testing**
- Pre-commit passed (including terraform validate with backend auth).
- Local apply with -refresh=false already run successfully (16 repos updated in-place).

**Checklist**
- [x] On feature branch
- [x] Pre-commit passing
- [x] Terse semantic commit