### PR TITLE
fix(terraform): use template-1-terraform for terraform-cloudflare

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -169,7 +169,7 @@ variable "repositories" {
       visibility  = "private"
       is_template = false
       template = {
-        repository = "template-cursor"
+        repository = "template-1-terraform"
       }
     }
   }


### PR DESCRIPTION
## Description
Use `template-1-terraform` instead of `template-cursor` when creating the terraform-cloudflare repo so CI (which may not have access to template-cursor) can apply successfully.

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- In `terraform/variables.tf`, set `terraform-cloudflare` template to `template-1-terraform`.