### PR TITLE
feat(terraform): fork open-ralph-wiggum into org as ralph-taskmaster-ai

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,15 @@ repos:
     rev: v1.9.2
     hooks:
       - id: tf-fmt
-      - id: tf-validate
-  # Ensure .terraform.lock.hcl is committed and in sync (pinned providers). Requires terraform on PATH.
+      # tf-validate omitted: requires backend auth; use local script (init -backend=false) below
   - repo: local
     hooks:
+      - id: terraform-validate-no-backend
+        name: terraform validate (init -backend=false)
+        entry: .github/scripts/terraform-pre-commit-validate.sh
+        language: system
+        files: ^terraform/.*\.(tf|hcl)$
+        pass_filenames: false
       - id: terraform-lockfile
         name: terraform lockfile in sync (pinned providers)
         entry: .github/scripts/terraform-lockfile-readonly.sh

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -21,6 +21,26 @@ provider "registry.terraform.io/hashicorp/local" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
 provider "registry.terraform.io/integrations/github" {
   version     = "5.14.0"
   constraints = "< 5.15.0"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,15 +75,13 @@ data "github_repository" "forked" {
   depends_on = [null_resource.fork]
 }
 
-# Branch protection for forked repos (uses repo default branch, e.g. main or master)
+# Branch protection for forked repos (uses repo default branch, e.g. main or master).
+# for_each keys must be known at plan time; use var.repository_forks so we don't depend on data source.
 resource "github_branch_protection" "forked_default_branch" {
-  for_each = {
-    for k, r in data.github_repository.forked : k => r
-    if r.visibility != "private"
-  }
+  for_each = { for f in var.repository_forks : coalesce(f.name, f.source_repo) => f }
 
-  repository_id = each.value.node_id
-  pattern       = each.value.default_branch
+  repository_id = data.github_repository.forked[each.key].node_id
+  pattern       = data.github_repository.forked[each.key].default_branch
 
   required_status_checks {
     strict   = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,12 +17,80 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.5"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }
 
 provider "github" {
   owner = "surefirev2"
   token = var.github_token
+}
+
+# Fork external repositories into the organization (GitHub API; no provider resource for fork).
+# If name != source_repo, renames the fork in the org to the desired name.
+resource "null_resource" "fork" {
+  for_each = { for f in var.repository_forks : coalesce(f.name, f.source_repo) => f }
+
+  triggers = {
+    source = "${each.value.source_owner}/${each.value.source_repo}"
+    name   = coalesce(each.value.name, each.value.source_repo)
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      SOURCE_OWNER="${each.value.source_owner}"
+      SOURCE_REPO="${each.value.source_repo}"
+      TARGET_NAME="${coalesce(each.value.name, each.value.source_repo)}"
+      # Fork into org (creates repo with same name as source)
+      curl -sSf -X POST \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Content-Type: application/json" \
+        -d '{"organization":"surefirev2"}' \
+        "https://api.github.com/repos/$SOURCE_OWNER/$SOURCE_REPO/forks"
+      # Rename in org if desired name differs from source repo name
+      if [ "$TARGET_NAME" != "$SOURCE_REPO" ]; then
+        curl -sSf -X PATCH \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Content-Type: application/json" \
+          -d "{\"name\":\"$TARGET_NAME\"}" \
+          "https://api.github.com/repos/surefirev2/$SOURCE_REPO"
+      fi
+    EOT
+    environment = {
+      GITHUB_TOKEN = var.github_token
+    }
+  }
+}
+
+# Look up forked repos so we can apply branch protection (after fork exists)
+data "github_repository" "forked" {
+  for_each   = { for f in var.repository_forks : coalesce(f.name, f.source_repo) => f }
+  full_name  = "surefirev2/${coalesce(each.value.name, each.value.source_repo)}"
+  depends_on = [null_resource.fork]
+}
+
+# Branch protection for forked repos (uses repo default branch, e.g. main or master)
+resource "github_branch_protection" "forked_default_branch" {
+  for_each = {
+    for k, r in data.github_repository.forked : k => r
+    if r.visibility != "private"
+  }
+
+  repository_id = each.value.node_id
+  pattern       = each.value.default_branch
+
+  required_status_checks {
+    strict   = true
+    contexts = ["pre-commit"]
+  }
+
+  enforce_admins = true
 }
 
 # Create organization-wide branch protection

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,3 +8,8 @@ output "repository_names" {
   description = "Names of the created repositories"
   value       = { for k, v in github_repository.repos : k => v.full_name }
 }
+
+output "forked_repository_urls" {
+  description = "URLs of repositories forked into the organization"
+  value       = { for k, v in data.github_repository.forked : k => v.html_url }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -197,3 +197,19 @@ variable "repository_settings" {
     has_wiki     = false
   }
 }
+
+variable "repository_forks" {
+  description = "Repositories to fork into the organization. name = repo name in org (defaults to source_repo)."
+  type = list(object({
+    source_owner = string
+    source_repo  = string
+    name         = optional(string) # name in org; default source_repo
+  }))
+  default = [
+    {
+      source_owner = "Th0rgal"
+      source_repo  = "open-ralph-wiggum"
+      name         = "ralph-taskmaster-ai"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Terraform: fork Th0rgal/open-ralph-wiggum into surefirev2 org as **ralph-taskmaster-ai** (GitHub API fork + rename). Adds branch protection for the forked repo and uses the existing Docker-based validate script in pre-commit so `terraform validate` runs without backend auth.

## Changes
- **terraform**: `repository_forks` variable (source_owner, source_repo, optional name); null_resource to fork via API and optionally rename; data source + branch protection for forked repo; `forked_repository_urls` output; null provider + lockfile.
- **pre-commit**: Use local `terraform-pre-commit-validate.sh` for validate (init -backend=false) instead of tf-validate hook that requires backend auth.

## Fix (GHA plan)
- **fork branch protection**: Use static `for_each` keys from `var.repository_forks` so plan-time keys are known; data source is read at apply (depends on null_resource.fork).