### PR TITLE
fix(docker): add curl for fork local-exec in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile
 FROM hashicorp/terraform:1.14.6
 
-# Install any additional tools or dependencies if needed
+# curl required for null_resource.fork local-exec (GitHub API fork/rename)
+RUN apk add --no-cache curl


### PR DESCRIPTION
## Summary
Terraform apply in GHA failed because the Terraform Docker image has no `curl`; the fork `null_resource` uses curl for GitHub API calls.

## Changes
- **Dockerfile**: `RUN apk add --no-cache curl` so local-exec provisioner (fork/rename) works in CI.