### PR TITLE
fix(terraform): make fork rename idempotent on 422

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,21 +45,20 @@ resource "null_resource" "fork" {
       SOURCE_OWNER="${each.value.source_owner}"
       SOURCE_REPO="${each.value.source_repo}"
       TARGET_NAME="${coalesce(each.value.name, each.value.source_repo)}"
-      # Fork into org (creates repo with same name as source)
-      curl -sSf -X POST \
-        -H "Authorization: token $GITHUB_TOKEN" \
-        -H "Accept: application/vnd.github.v3+json" \
-        -H "Content-Type: application/json" \
+      AUTH="Authorization: token $GITHUB_TOKEN"
+      ACCEPT="Accept: application/vnd.github.v3+json"
+      # Fork into org (creates repo with same name as source, or returns existing fork)
+      curl -sSf -X POST -H "$AUTH" -H "$ACCEPT" -H "Content-Type: application/json" \
         -d '{"organization":"surefirev2"}' \
-        "https://api.github.com/repos/$SOURCE_OWNER/$SOURCE_REPO/forks"
-      # Rename in org if desired name differs from source repo name
+        "https://api.github.com/repos/$SOURCE_OWNER/$SOURCE_REPO/forks" >/dev/null
+      # Rename in org if desired name differs from source repo name (idempotent: 422 = already exists)
       if [ "$TARGET_NAME" != "$SOURCE_REPO" ]; then
-        curl -sSf -X PATCH \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Content-Type: application/json" \
+        if ! curl -sSf -X PATCH -H "$AUTH" -H "$ACCEPT" -H "Content-Type: application/json" \
           -d "{\"name\":\"$TARGET_NAME\"}" \
-          "https://api.github.com/repos/surefirev2/$SOURCE_REPO"
+          "https://api.github.com/repos/surefirev2/$SOURCE_REPO"; then
+          # PATCH can return 422 if target name already exists (e.g. from previous apply); verify target repo exists
+          curl -sSf -o /dev/null "https://api.github.com/repos/surefirev2/$TARGET_NAME" -H "$AUTH" -H "$ACCEPT" || exit 1
+        fi
       fi
     EOT
     environment = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,16 +47,17 @@ resource "null_resource" "fork" {
       TARGET_NAME="${coalesce(each.value.name, each.value.source_repo)}"
       AUTH="Authorization: token $GITHUB_TOKEN"
       ACCEPT="Accept: application/vnd.github.v3+json"
-      # Fork into org (creates repo with same name as source, or returns existing fork)
+      CODE=$(curl -sS -o /dev/null -w "%%{http_code}" "https://api.github.com/repos/surefirev2/$TARGET_NAME" -H "$AUTH" -H "$ACCEPT")
+      [ "$CODE" = "200" ] && exit 0
+      # Fork into org
       curl -sSf -X POST -H "$AUTH" -H "$ACCEPT" -H "Content-Type: application/json" \
         -d '{"organization":"surefirev2"}' \
         "https://api.github.com/repos/$SOURCE_OWNER/$SOURCE_REPO/forks" >/dev/null
-      # Rename in org if desired name differs from source repo name (idempotent: 422 = already exists)
+      # Rename in org if name != source (idempotent on 422)
       if [ "$TARGET_NAME" != "$SOURCE_REPO" ]; then
         if ! curl -sSf -X PATCH -H "$AUTH" -H "$ACCEPT" -H "Content-Type: application/json" \
           -d "{\"name\":\"$TARGET_NAME\"}" \
           "https://api.github.com/repos/surefirev2/$SOURCE_REPO"; then
-          # PATCH can return 422 if target name already exists (e.g. from previous apply); verify target repo exists
           curl -sSf -o /dev/null "https://api.github.com/repos/surefirev2/$TARGET_NAME" -H "$AUTH" -H "$ACCEPT" || exit 1
         fi
       fi
@@ -74,8 +75,7 @@ data "github_repository" "forked" {
   depends_on = [null_resource.fork]
 }
 
-# Branch protection for forked repos (uses repo default branch, e.g. main or master).
-# for_each keys must be known at plan time; use var.repository_forks so we don't depend on data source.
+# Branch protection for forked repos (default branch e.g. main or master)
 resource "github_branch_protection" "forked_default_branch" {
   for_each = { for f in var.repository_forks : coalesce(f.name, f.source_repo) => f }
 


### PR DESCRIPTION
## Summary
GHA apply failed on re-run: POST fork returns 200 (existing fork), PATCH rename returns 422 (target repo name already exists).

## Changes
- **terraform/main.tf**: Fork provisioner idempotent: if PATCH rename fails (e.g. 422), GET target repo; if 200, treat as success. Suppress fork POST body. Skip fork when target repo already exists (avoids duplicate -1, -2). Trim comments (deslop).