### PR TITLE
feat(terraform): add ethan_carpentry repository

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -190,6 +190,15 @@ variable "repositories" {
         repository = ""
       }
     }
+    "ethan_carpentry" = {
+      name        = "ethan_carpentry"
+      description = "Ethans Carpetnry project"
+      visibility  = "private"
+      is_template = false
+      template = {
+        repository = ""
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Adds the `ethan_carpentry` private repository to the Terraform `repositories` default map for the surefirev2 GitHub org.

## Type of change

- New feature

## Changes made

- Extend `terraform/variables.tf` `repositories` with `ethan_carpentry` (private, non-template, empty template block consistent with similar repos).

## Testing

- `pre-commit run --all-files` (terraform fmt, validate)

## Checklist

- [x] Pre-commit passes
- [ ] Confirm `make plan` / apply aligns with org expectations before merge