### PR TITLE
feat(terraform): add comics_self_hosted private repo

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -208,6 +208,15 @@ variable "repositories" {
         repository = "template_template"
       }
     }
+    "comics_self_hosted" = {
+      name        = "comics_self_hosted"
+      description = "Self-hosted comics stack"
+      visibility  = "private"
+      is_template = false
+      template = {
+        repository = "template_template"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Adds `comics_self_hosted` to the Terraform-managed repository map as a private repo generated from `template_template` (`surefirev2/template-template`), matching the `comics_tauri` pattern.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Register `comics_self_hosted` in `terraform/variables.tf` with private visibility and template source `template_template`

## Testing

- [x] `make plan` — shows 1 repo to add (`github_repository.repos["comics_self_hosted"]`)
- [ ] `make apply` or merge and let CI apply to create the GitHub repository

## Checklist

- [x] Pre-commit passed
- [x] Terraform validate passed

## Related Issues

N/A