### PR TITLE
feat(terraform): add math-desktop repository

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -154,6 +154,15 @@ variable "repositories" {
         repository = "template-cursor"
       }
     }
+    "math-desktop" = {
+      name        = "math-desktop"
+      description = "Epiphanie math desktop app"
+      visibility  = "private"
+      is_template = false
+      template = {
+        repository = "template-template"
+      }
+    }
     "private_ai" = {
       name        = "private_ai"
       description = "TBD"


### PR DESCRIPTION
## Summary
- Add `math-desktop` to Terraform-managed repositories
- Private repo generated from `template-template`
- Repo already exists on GitHub and was imported into state; this keeps config in sync

## Test plan
- [ ] Terraform CI plan shows only expected `math-desktop` resource changes
- [ ] Apply succeeds without recreating the existing repository