### PR TITLE
feat(terraform): add kevinwm0 collaborator on math_spike2

### DIFF
--- a/scripts/terraform-import-existing.sh
+++ b/scripts/terraform-import-existing.sh
@@ -27,12 +27,12 @@ FORK_KEY="ralph-taskmaster-ai"
 declare -a REPO_KEYS=(
   cursor nuxt-ucda invoice-x12-converter comic-reader rfp-langchain gallery tutorv1 repo-scan
   info-amalgamator lumen math_spike1 math_spike2 math_langchain math_instructure math_nuxt_chat_ui
-  private_ai terraform-cloudflare repo-sync-action
+  math-desktop private_ai terraform-cloudflare repo-sync-action
 )
 declare -a REPO_NAMES=(
   template-cursor nuxt-ucda invoice-x12-converter comic-reader rfp-langchain gallery tutorv1 repo-scan
   info-amalgamator lumen math_spike1 math_spike2 math_langchain math_instructure math_nuxt_chat_ui
-  private_ai terraform-cloudflare repo-sync-action
+  math-desktop private_ai terraform-cloudflare repo-sync-action
 )
 
 for i in "${!REPO_KEYS[@]}"; do

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -147,3 +147,22 @@ resource "github_repository" "repos" {
     ]
   }
 }
+
+resource "github_repository_collaborator" "collaborators" {
+  for_each = {
+    for pair in flatten([
+      for repo_key, users in var.repository_collaborators : [
+        for user in users : {
+          key        = "${repo_key}:${user.username}"
+          repo_key   = repo_key
+          username   = user.username
+          permission = user.permission
+        }
+      ]
+    ]) : pair.key => pair
+  }
+
+  repository = github_repository.repos[each.value.repo_key].name
+  username   = each.value.username
+  permission = each.value.permission
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -102,7 +102,7 @@ resource "github_branch_protection" "default_branch" {
 
   required_status_checks {
     strict   = true
-    contexts = ["pre-commit"]
+    contexts = lookup(var.branch_protection_status_checks, each.key, ["pre-commit"])
   }
 
   enforce_admins = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -234,6 +234,14 @@ variable "repository_settings" {
   }
 }
 
+variable "branch_protection_status_checks" {
+  description = "Required status check contexts per repository key (defaults to pre-commit when absent)"
+  type        = map(list(string))
+  default = {
+    hockeymind = ["e2e (blacksmith-4vcpu-ubuntu-2404, 22)"]
+  }
+}
+
 variable "repository_collaborators" {
   description = "Outside collaborators per repository (keys must match var.repositories)"
   type = map(list(object({

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -234,6 +234,22 @@ variable "repository_settings" {
   }
 }
 
+variable "repository_collaborators" {
+  description = "Outside collaborators per repository (keys must match var.repositories)"
+  type = map(list(object({
+    username   = string
+    permission = string # pull, triage, push, maintain, admin
+  })))
+  default = {
+    math_spike2 = [
+      {
+        username   = "kevinwm0"
+        permission = "maintain"
+      }
+    ]
+  }
+}
+
 variable "repository_forks" {
   description = "Repositories to fork into the organization. name = repo name in org (defaults to source_repo)."
   type = list(object({

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -154,6 +154,15 @@ variable "repositories" {
         repository = "template-cursor"
       }
     }
+    "math-desktop" = {
+      name        = "math-desktop"
+      description = "Epiphanie math desktop app"
+      visibility  = "private"
+      is_template = false
+      template = {
+        repository = ""
+      }
+    }
     "private_ai" = {
       name        = "private_ai"
       description = "TBD"


### PR DESCRIPTION
## Summary

- Add `repository_collaborators` variable and `github_repository_collaborator` resource for per-repo outside collaborator access
- Grant `kevinwm0` maintain permission on `math_spike2` only
- Add `branch_protection_status_checks` override so `hockeymind` keeps `e2e (blacksmith-4vcpu-ubuntu-2404, 22)` instead of default `pre-commit`
- Add `math-desktop` to `var.repositories` so existing state is not destroyed on apply
- Include `math-desktop` in `scripts/terraform-import-existing.sh`

## Test plan

- [x] `make validate` passes locally
- [x] `make plan` shows `github_repository_collaborator.collaborators["math_spike2:kevinwm0"]` to create
- [x] `make plan` shows `0 to destroy` for `math-desktop`
- [x] `make plan` shows no drift on `hockeymind` branch protection
- [ ] CI Terraform plan on PR reviewed
- [ ] Merge to `main` to apply; `kevinwm0` accepts GitHub invitation if required