### PR TITLE
fix(terraform): ignore ghas attrs on github repos

### DIFF
--- a/terraform-1password.md
+++ b/terraform-1password.md
@@ -49,4 +49,6 @@ If init fails with `HeadObject` / `403 Forbidden` on the state object, the IAM p
 
 After `make init` succeeds against S3, run [`scripts/terraform-import-existing.sh`](scripts/terraform-import-existing.sh) with `.env` loaded. It imports repositories, applies `null_resource.fork` for the fork, then imports branch protections. The fork repo’s default branch is **`master`** (not `main`); override with `FORK_DEFAULT_BRANCH=...` if needed.
 
-If drift remains (e.g. `ignore_vulnerability_alerts_during_read`), run `make apply` once to sync, then `make plan` should report **No changes**.
+If drift remains after import, run `make apply` once to sync, then `make plan` should report **No changes**.
+
+This org does not use GitHub Advanced Security (GHAS). Repository resources ignore `security_and_analysis`, `vulnerability_alerts`, and other provider 5.45+ attributes that would otherwise trigger PATCHes GitHub rejects on private repos without GHAS.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -145,16 +145,18 @@ resource "github_repository" "repos" {
   allow_update_branch    = true
   delete_branch_on_merge = true
 
-  # Skip reading vulnerability_alerts so plan/apply works when the token or org
-  # cannot access the endpoint (403: Resource not accessible by integration).
-  # We do not manage vulnerability_alerts; lifecycle.ignore_changes already
-  # ignores drift for vulnerability_alerts and security_and_analysis.
+  # Org does not subscribe to GitHub Advanced Security (GHAS). Skip reading
+  # vulnerability_alerts (403 without the right token scope) and ignore all
+  # security-related attributes so provider 5.45+ does not PATCH repos with
+  # Advanced Security fields (422 on private repos without GHAS).
   ignore_vulnerability_alerts_during_read = true
 
   lifecycle {
     ignore_changes = [
       vulnerability_alerts,
       security_and_analysis,
+      web_commit_signoff_required,
+      topics,
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Ignore `web_commit_signoff_required` and `topics` on `github_repository.repos` to stop provider 5.45+ drift from triggering repo PATCHes
- Document that the org does not use GitHub Advanced Security (GHAS); existing ignores on `security_and_analysis` and `vulnerability_alerts` remain

Fixes failed apply on `main` after PR #158 (`422 Updating Advanced Security on ethan_carpentry`).

## Test plan

- [x] `make validate` passes locally
- [x] `make plan` shows no changes
- [ ] CI Terraform plan on PR reviewed
- [ ] Merge to `main` and confirm apply succeeds (expected: no changes)