### PR TITLE
feat(terraform): enable github pages on math-desktop

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -280,6 +280,11 @@ variable "repository_pages" {
       source_branch = "main"
       source_path   = "/"
     }
+    "math-desktop" = {
+      build_type    = "workflow"
+      source_branch = "main"
+      source_path   = "/"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Enable GitHub Pages on `math-desktop` with workflow-based deployment (GitHub Actions)
- Matches the existing `math_spike2` Pages configuration in `repository_pages`

## Type of Change
- [x] Infrastructure / Terraform
- [ ] Bug fix
- [ ] Documentation

## Changes Made
- Add `math-desktop` entry to `var.repository_pages` with `build_type = "workflow"`

## Testing
- [x] `terraform validate` passes
- [x] `make plan` shows in-place update adding `pages` block to `github_repository.repos["math-desktop"]`

## Checklist
- [x] Pre-commit hooks pass
- [ ] Terraform apply after merge

## Related Issues
N/A