### PR TITLE
feat(terraform): add private revive repository

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -226,6 +226,15 @@ variable "repositories" {
         repository = "template_template"
       }
     }
+    "revive" = {
+      name        = "revive"
+      description = "TBD"
+      visibility  = "private"
+      is_template = false
+      template = {
+        repository = "template-cursor"
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Add a new private GitHub repository `revive` to Terraform-managed repositories, created from the `template-cursor` template.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Add `revive` entry to `var.repositories` in `terraform/variables.tf` with private visibility

## Testing

- [x] `terraform validate` passes (via pre-commit)

## Checklist

- [x] Pre-commit hooks pass
- [x] Terraform configuration validates

## Related Issues

N/A